### PR TITLE
Changes to check for RB_CN

### DIFF
--- a/Plugins/SeleCR/Settings.cs
+++ b/Plugins/SeleCR/Settings.cs
@@ -454,6 +454,7 @@
                     }
                     break;
 
+		#if !RB_CN
                 case ClassJobType.Viper:
                     if (WorldManager.InPvP)
                     {
@@ -491,7 +492,7 @@
                             return Pvp.PictomancerRoutine;
                     }
                     break;
-
+		#endif
 
                 default:
                     return "";

--- a/Plugins/SeleCR/SettingsWindow.cs
+++ b/Plugins/SeleCR/SettingsWindow.cs
@@ -108,6 +108,20 @@ namespace CarbuncleTech.Plugins.SeleCR
             cmbViperPVP.Items.AddRange(routines);
             cmbPictomancerPVE.Items.AddRange(routines);
             cmbPictomancerPVP.Items.AddRange(routines);
+
+
+	    #if RB_CN
+            picViperPVE.Visible = false;
+            picViperPVP.Visible = false;
+            picPictomancerPVE.Visible = false;
+            picPictomancerPVP.Visible = false;
+
+
+	    cmbViperPVE.Visible = false;
+	    cmbViperPVP.Visible = false;
+	    cmbPictomancerPVE.Visible = false;
+	    cmbPictomancerPVP.Visible = false;
+	    #endif
         }
 
         private string GetImageLocation(string fileName)


### PR DESCRIPTION
Added checks for RB_CN to Viper/Picto. Forgot these needed to be there since CN client doesn't have Dawntrail yet.